### PR TITLE
Roman Numerals (reference PR)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -196,7 +196,7 @@ Style/IfWithSemicolon:
 
 Style/InlineComment:
   Description: "Avoid inline comments."
-  Enabled: true
+  Enabled: false
 
 Style/Lambda:
   Description: "Use the new lambda literal syntax for single-line blocks."
@@ -366,7 +366,7 @@ Style/TrailingCommaInArguments:
     - comma
     - consistent_comma
     - no_comma
-  Enabled: true
+  Enabled: false
 
 Style/TrailingCommaInArrayLiteral:
   Description: "Checks for trailing comma in array literals."
@@ -376,7 +376,7 @@ Style/TrailingCommaInArrayLiteral:
     - comma
     - consistent_comma
     - no_comma
-  Enabled: true
+  Enabled: false
 
 Style/TrailingCommaInHashLiteral:
   Description: "Checks for trailing comma in hash literals."
@@ -386,7 +386,7 @@ Style/TrailingCommaInHashLiteral:
     - comma
     - consistent_comma
     - no_comma
-  Enabled: true
+  Enabled: false
 
 Style/TrivialAccessors:
   Description: "Prefer attr_* methods to trivial readers/writers."

--- a/roman_numerals/roman_convertable.rb
+++ b/roman_numerals/roman_convertable.rb
@@ -1,0 +1,29 @@
+module RomanConvertable
+  ROMAN_DIGITS = {
+    "M" => 1000,
+    "CM" => 900,
+    "D" => 500,
+    "CD" => 400,
+    "C" => 100,
+    "XC" => 90,
+    "L" => 50,
+    "XL" => 40,
+    "X" => 10,
+    "IX" => 9,
+    "V" => 5,
+    "IV" => 4,
+    "I" => 1
+  }.freeze
+
+  def to_roman
+    num = self
+    raise(RangeError, "Number must be from 1-3999") unless num < 4000 && num.positive?
+
+    "".tap do |roman_numeral|
+      ROMAN_DIGITS.each do |key, value|
+        roman_numeral << key * (num / value)
+        num %= value
+      end
+    end
+  end
+end

--- a/roman_numerals/roman_convertable.rb
+++ b/roman_numerals/roman_convertable.rb
@@ -15,14 +15,16 @@ module RomanConvertable
     "I" => 1
   }.freeze
 
-  def to_roman
-    num = self
-    raise(RangeError, "Number must be from 1-3999") unless num < 4000 && num.positive?
+  refine Integer do
+    def to_roman
+      num = self
+      raise(RangeError, "Number must be from 1-3999") unless num < 4000 && num.positive?
 
-    "".tap do |roman_numeral|
-      ROMAN_DIGITS.each do |key, value|
-        roman_numeral << key * (num / value)
-        num %= value
+      "".tap do |roman_numeral|
+        ROMAN_DIGITS.each do |key, value|
+          roman_numeral << key * (num / value)
+          num %= value
+        end
       end
     end
   end

--- a/roman_numerals/to_roman_numeral.rb
+++ b/roman_numerals/to_roman_numeral.rb
@@ -3,10 +3,10 @@ require_relative "roman_convertable"
 
 Integer.include RomanConvertable
 
-print "Enter a number: "
+print "Enter a number to convert to roman numerals: "
 number = gets.to_i
 begin
-  puts number.to_roman
+  puts "#{number} is #{number.to_roman} in roman numerals"
 rescue RangeError => e
   puts e.message
 end

--- a/roman_numerals/to_roman_numeral.rb
+++ b/roman_numerals/to_roman_numeral.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative "roman_convertable"
 
-Integer.include RomanConvertable
+using RomanConvertable
 
 print "Enter a number to convert to roman numerals: "
 number = gets.to_i

--- a/roman_numerals/to_roman_numeral.rb
+++ b/roman_numerals/to_roman_numeral.rb
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require_relative "roman_convertable"
+
+Integer.include RomanConvertable
+
+print "Enter a number: "
+number = gets.to_i
+begin
+  puts number.to_roman
+rescue RangeError => e
+  puts e.message
+end

--- a/spec/roman_numerals/roman_convertable_spec.rb
+++ b/spec/roman_numerals/roman_convertable_spec.rb
@@ -1,0 +1,68 @@
+require_relative "../../roman_numerals/roman_convertable"
+
+using RomanConvertable
+
+describe RomanConvertable do
+  describe "#to_roman" do
+    context "when called on a valid number" do
+      let(:three) { 3 }
+      let(:nine) { 9 }
+      let(:twenty_eight) { 28 }
+      let(:two_hundred) { 200 }
+      let(:five_hundred_forty) { 540 }
+      let(:eight_hundred_two) { 802 }
+      let(:nine_hundred_twenty_five) { 925 }
+      let(:max_valid_number) { 3_999 }
+
+      it "correctly converts 3" do
+        expect(three.to_roman).to eql("III")
+      end
+
+      it "correctly converts 9" do
+        expect(nine.to_roman).to eql("IX")
+      end
+
+      it "correctly converts 28" do
+        expect(twenty_eight.to_roman).to eql("XXVIII")
+      end
+
+      it "correctly converts 200" do
+        expect(two_hundred.to_roman).to eql("CC")
+      end
+
+      it "correctly converts 540" do
+        expect(five_hundred_forty.to_roman).to eql("DXL")
+      end
+
+      it "correctly converts 802" do
+        expect(eight_hundred_two.to_roman).to eql("DCCCII")
+      end
+
+      it "correctly converts 925" do
+        expect(nine_hundred_twenty_five.to_roman).to eql("CMXXV")
+      end
+
+      it "correctly converts the maximum valid number, 3999" do
+        expect(max_valid_number.to_roman).to eql("MMMCMXCIX")
+      end
+    end
+
+    context "when called on an invalid number" do
+      let(:zero) { 0 }
+      let(:overflow) { 4000 }
+      let(:negative) { -1 }
+
+      it "throws an exception when called on zero" do
+        expect { zero.to_roman }.to raise_error(RangeError)
+      end
+
+      it "throws an exception when called on number that's too large" do
+        expect { overflow.to_roman }.to raise_error(RangeError)
+      end
+
+      it "throws an exception when called on a negative number" do
+        expect { negative.to_roman }.to raise_error(RangeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# About this PR
A solution for the roman numerals conversion problem

## Description
Monkey patches `Integer` built in class to provide additional `to_roman` functionality

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* Additional reference for TDD and refactoring logic to modules and classes
* Introduces `refinements` in Ruby, a safer way to monkey patch classes

## How Has This Been Tested?
- [x] Added spec
- [x] Build is passing

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] My pull request is small so it can be easily reviewed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
